### PR TITLE
misc cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,13 +51,13 @@ version = "0.3"
 
 [dependencies.rdkafka]
 features = ["cmake-build", "gssapi", "ssl", "tokio"]
-# version = "0.24.0"
-git = "https://github.com/fede1024/rust-rdkafka"
-rev = "8da55e2c58752d75babb800edc0162b519dd84e2"
+version = "0.26.0"
+# git = "https://github.com/fede1024/rust-rdkafka"
+# rev = "8da55e2c58752d75babb800edc0162b519dd84e2"
 
 [dependencies.tokio]
 features = ["rt-multi-thread", "macros", "io-util"]
-version = "1.0"
+version = "1.5"
 
 [dependencies.tokio-postgres]
 features = ["with-chrono-0_4"]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -37,5 +37,5 @@ pub enum AppError {
 	IoError(#[from] io::Error),
 
 	#[error(transparent)]
-	TLSError(#[from] native_tls::Error),
+	TlsError(#[from] native_tls::Error),
 }

--- a/src/kafka/consumer.rs
+++ b/src/kafka/consumer.rs
@@ -82,7 +82,7 @@ impl KafkaConsumer {
 	pub async fn consume(&self, sender_tx: mpsc::Sender<BytesMut>) {
 		debug!("initiating data consumption from kafka-topic");
 
-		let mut message_stream = self.kafka_consumer.start();
+		let mut message_stream = self.kafka_consumer.stream();
 		while let Some(message) = message_stream.next().await {
 			match message {
 				Err(e) => warn!("Kafka error: {}", e),

--- a/src/postgres/mod.rs
+++ b/src/postgres/mod.rs
@@ -1,2 +1,2 @@
 mod client;
-pub use client::DBClient;
+pub use client::DbClient;


### PR DESCRIPTION
### Description:
- fix clippy lint
- pin tokio and rdkafka to latest versions
- removed deprecated method `start()` from kafka-consumer and using `stream()`